### PR TITLE
Change name of inputs in action.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM bash
 
-LABEL version="1.0.1"
+LABEL version="1.0.2"
 
 RUN apk --no-cache add jq curl grep
 

--- a/action.yml
+++ b/action.yml
@@ -5,10 +5,10 @@ branding:
   color: blue
 author: dudo
 inputs:
-  INPUT_VERSION:
+  version:
     description: Declare this variable if you don't want the version inferred.
     required: false
-  INPUT_GIT_TAG_PREFIX:
+  git_tag_prefix:
     description: What to use in front of your version? eg. v, ver.
     required: false
   GITHUB_REPOSITORY:


### PR DESCRIPTION
Fix #1.

A warning is generated when using the `git_tag_prefix` as shown in the readme.  This is because the input was defined in `action.yml` as `INPUT_GIT_TAG_PREFIX`, which not what the input should be, rather that is the environment variable that gets created to store the input value.  The environment variable `INPUT_GIT_TAG_PREFIX` is used correctly in `entrypoint.sh`

Reference [docs.github.com](https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/metadata-syntax-for-github-actions#inputs):
> When you specify an input to an action in a workflow file or use a
> default input value, GitHub creates an environment variable for the
> input with the name INPUT_<VARIABLE_NAME>. The environment variable
> created converts input names to uppercase letters and replaces spaces
> with _ characters.
> 
> For example, if a workflow defined the numOctocats and octocatEyeColor
> inputs, the action code could read the values of the inputs using the
> INPUT_NUMOCTOCATS and INPUT_OCTOCATEYECOLOR environment variables.